### PR TITLE
Convert to next/Image

### DIFF
--- a/components/ProfileImage.jsx
+++ b/components/ProfileImage.jsx
@@ -1,12 +1,15 @@
 import React from "react";
+import Image from "next/image";
 
 const ProfileImage = ({ image }) => {
   return (
     <div className="flex justify-center items-center flex-col p-2 bg-white rounded-full">
-      <img
+      <Image
         src={image}
         alt="photo_url"
-        className=" scale-125 mt-3 rounded-full"
+        className="scale-125 mt-3 rounded-full"
+        width={100}
+        height={100}
       />
 
       <div className="mt-20 p-0">

--- a/components/Profiledrop.jsx
+++ b/components/Profiledrop.jsx
@@ -4,6 +4,7 @@ import { FaChevronRight } from "react-icons/fa";
 import { FaChevronDown, FaTrash, FaPencilAlt, FaCheck } from "react-icons/fa";
 import { Accordion, Col, Row } from "react-bootstrap";
 import axios from "axios";
+import Image from "next/image";
 
 const colors = [
   "bg-beatdrop-orange",
@@ -91,7 +92,7 @@ const Profiledrop = ({
             <div className=" px-3 ">{index + 1}</div>
             <div className="flex  col-span-5">
               {image && (
-                <img
+                <Image
                   className=" rounded-full mx-3 "
                   alt="album cover"
                   src={image}
@@ -134,9 +135,12 @@ const Profiledrop = ({
         <Accordion.Body className="m-0 p-0 w-full mb-4 bg-white">
           <Row className="w-full m-0 p-0">
             <Col xl={6} className="flex justify-center items-center mr-0 p-0">
-              <img
+              <Image
                 src={`https://maps.googleapis.com/maps/api/staticmap?center=${location.lat},${location.long}&markers=color:0xE12A62%7Clabel:B%7C${location.lat},${location.long}&zoom=15&size=500x300&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}`}
                 className="rounded-bl-4xl border-r-4 border-white"
+                alt="map image"
+                width={500}
+                height={500}
               />
             </Col>
             <Col
@@ -167,7 +171,7 @@ const Profiledrop = ({
               </div>
 
               <textarea
-                className="m-0 p-0 font-outfit flex justify-start break-words rounded-lg p-2"
+                className="m-0 font-outfit flex justify-start break-words rounded-lg p-2"
                 disabled={!edit}
                 value={descriptionInput}
                 onChange={(e) => setDescriptionInput(e.target.value)}

--- a/components/Song.jsx
+++ b/components/Song.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 import { HiArrowNarrowRight } from "react-icons/hi";
 
 const Song = ({
@@ -52,12 +53,14 @@ const Song = ({
       {song && image && artist && (
         <>
           <div className="flex items-center justify-start gap-3">
-            <img
+            <Image
               src={image}
-              placeholder="blur"
+              //placeholder="blur"
               blurd="true"
               alt="album cover"
               className="rounded-full w-1/5"
+              width={150}
+              height={150}
             />
             <div className="flex flex-col items-start justify-start !text-black ">
               <div className="text-songName font-semibold m-0 p-0 text-left ">

--- a/components/Upload.jsx
+++ b/components/Upload.jsx
@@ -7,6 +7,7 @@ import { auth } from "@/firebase";
 import axios from "axios";
 import Dropdown from "react-bootstrap/Dropdown";
 import { Col, Row } from "react-bootstrap";
+import Image from "next/image";
 
 const colors = [
   "bg-beatdrop-orange",
@@ -152,7 +153,14 @@ const Upload = ({ setToggleUpload, token }) => {
           )}
           {image !== "" && (
             <div className="bg-[#EBEBEB] rounded-xl w-9/12 aspect-square flex justify-center items-center">
-              <img src={image} className="rounded-2xl w-full h-full" />
+              <Image
+                src={image}
+                className="rounded-2xl w-full h-full"
+                alt="album"
+                //unsure about these values below. not sure which image this is.
+                width={500}
+                height={500}
+              />
             </div>
           )}
 
@@ -195,9 +203,12 @@ const Upload = ({ setToggleUpload, token }) => {
                     }}
                     className="!flex justify-start items-center"
                   >
-                    <img
+                    <Image
                       src={result.album.images[0].url}
-                      className="rounded-full w-10 h-10"
+                      className="rounded-full"
+                      alt="album image"
+                      width={40}
+                      height={40}
                     />
                     <p className="mb-0">
                       {result.name} by {result.artists[0].name}

--- a/components/View.jsx
+++ b/components/View.jsx
@@ -4,6 +4,7 @@ import Row from "react-bootstrap/Row";
 import { FaRegStar, FaTimes, FaStar, FaPlay, FaPause } from "react-icons/fa";
 import axios from "axios";
 import useAudio from "./useAudio";
+import Image from "next/image";
 
 const colors = [
   "bg-beatdrop-orange",
@@ -82,7 +83,13 @@ const View = ({
         >
           <div className="flex justify-center items-center flex-col">
             <div className="relative flex justify-center items-center">
-              <img src={image} alt="Album" className="rounded-3xl w-9/12" />
+              <Image
+                src={image}
+                alt="Album"
+                className="rounded-3xl w-9/12"
+                width={500}
+                height={500}
+              />
               {previewurl && (
                 <div
                   onClick={audioToggle}

--- a/components/WhoIsBeatdrop.jsx
+++ b/components/WhoIsBeatdrop.jsx
@@ -24,7 +24,7 @@ const WhoIsBeatdrop = () => {
             </ul>
           </div>
           <p className="text-md ml-4 px-3">
-            But as of this exact second, ‘we’ includes you. BeatDrop is you.
+            But as of this exact second, ‘we’ includes you! BeatDrop is you.
             BeatDrop is us. Thank you for being here and taking on life with us.
             <span className="text-beatdrop-pink font-bold">
               {" "}

--- a/next.config.js
+++ b/next.config.js
@@ -4,3 +4,29 @@ const nextConfig = {
 };
 
 module.exports = nextConfig;
+
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+        // hostname: 'lh3.googleusercontent.com',
+      },
+    ],
+  },
+};
+
+//Unsure if above is safe, but it works for now.
+//tried to add remotePatterns below but wasn't recognizing both.
+
+// module.exports = {
+//   images: {
+//     remotePatterns: [
+//       {
+//         protocol: 'https',
+//         hostname: "i.scdn.co",
+//       },
+//     ],
+//   },
+// };


### PR DESCRIPTION
Changed `img` usage to `next/Image` for optimization and to clear Eslint warnings. 
Had to add remotePatterns to next.config.js. Added all hostnames, which might not be the safest and might need to be changed, but works for now. 
Also had to add `height` and `width` fields with pixel values, as required by `next/Image`. Some of the `img` didn't have either of these values, so I had to guess and put values that sized it to how it was before.