### PR TITLE
Add expo image picker

### DIFF
--- a/components/create/details.tsx
+++ b/components/create/details.tsx
@@ -1,5 +1,4 @@
 import Entypo from "@expo/vector-icons/Entypo";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 import Tag from "@/components/global/tag";
 import Beat from "@/components/global/beat";
 import { View, Text, TextInput, Pressable, Keyboard } from "react-native";
@@ -13,6 +12,7 @@ import Tags from "@/assets/icons/Tags.svg";
 import Cross from "@/assets/icons/Cross.svg";
 import Plus from "@/assets/icons/Plus.svg";
 import ArrowDown from "@/assets/icons/ArrowDown.svg";
+import * as ImagePicker from "expo-image-picker";
 
 const colors = [
   "bg-beatdrop-tag-orange",
@@ -44,6 +44,24 @@ const Details = ({
   const handleAdd = (value: string) => {
     addTag(value);
     setTag("");
+  };
+
+  const [images, setImages] = useState<ImagePicker.ImagePickerAsset[]>([]);
+  const handlePromptImage = async () => {
+    const response = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      quality: 1,
+      allowsMultipleSelection: true,
+      selectionLimit: 3,
+    });
+
+    if (response.canceled || !response.assets) {
+      return;
+    }
+
+    const allImages = [...response.assets, ...images];
+
+    setImages(allImages);
   };
 
   return (
@@ -109,6 +127,26 @@ const Details = ({
           {tags.map((tag, index) => (
             <Tag text={tag} color={colors[index]} key={index} />
           ))}
+        </View>
+        <View className="flex flex-row flex-wrap gap-2 items-center">
+          <Pressable
+            onPress={handlePromptImage}
+            className="flex flex-row items-center gap-2"
+          >
+            <Text>Upload image + </Text>
+          </Pressable>
+
+          {images.map((image) => {
+            return (
+              <Image
+                key={image.uri}
+                source={{ uri: image.uri }}
+                style={{ width: 40, height: 40, borderRadius: 8 }}
+                contentFit="cover"
+                alt="Selected Image"
+              />
+            );
+          })}
         </View>
       </View>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo-constants": "~16.0.2",
         "expo-font": "~12.0.9",
         "expo-image": "~1.12.13",
+        "expo-image-picker": "~15.0.7",
         "expo-linking": "~6.3.1",
         "expo-router": "~3.5.21",
         "expo-splash-screen": "~0.27.5",
@@ -11295,6 +11296,25 @@
       "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-1.12.13.tgz",
       "integrity": "sha512-Dmuc5qmkIsl1nFj8C3Ux3wL2bN4QYW4dM9fkGA8kYiP5Fxf1lT36ldkHk2O2lPFRSFJDvLxT8Tz+7GTko5fzwQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-15.0.7.tgz",
+      "integrity": "sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
-    "react-native-web": "~0.19.10"
+    "react-native-web": "~0.19.10",
+    "expo-image-picker": "~15.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
This PR adds expo-image-picker to the repo and an example use case in the new beat drop bottom sheet. I was unsure where this will be officially used but this logic can be moved anywhere easily.